### PR TITLE
Add convenient method to store serializable items list onto bundle

### DIFF
--- a/amalgam/src/main/java/com/amalgam/os/BundleUtils.java
+++ b/amalgam/src/main/java/com/amalgam/os/BundleUtils.java
@@ -1093,4 +1093,15 @@ public final class BundleUtils {
         }
         return bundle.keySet();
     }
+
+    /**
+     * Convenient method to save {@link java.util.ArrayList} containing {@link java.io.Serializable} items onto {@link android.os.Bundle}.
+     * Since it fails to save a list that containing not {@link java.io.Serializable} items with {@link android.os.Bundle#putSerializable(String, Serializable)} at runtime,
+     * this is useful to get an information about putting non-serializable items array list at compile time.
+     * @param bundle a bundle.
+     * @param list to be stored on the bundle.
+     */
+    public static void putSerializableArrayList(@NonNull Bundle bundle, @NonNull String key, @NonNull ArrayList<? extends Serializable> list) {
+        bundle.putSerializable(key, list);
+    }
 }


### PR DESCRIPTION
I've added convenience method that can detect common programming error at compile-time.

Since `ArrayList` is serializable, compilation will succeed even if we put an `ArrayList` that has non-serializable items using `Bundle#putSerializable(String, Serializable)`, but it does not work as expected.

It's safe to see an error message at compilation time so I've added convenience method.